### PR TITLE
Pin pytest version because usage of ContextsCollector is deprecated

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     long_description=read('README.rst'),
     py_modules=['pytest_contexts'],
     python_requires='>=3.6',
-    install_requires=['pytest', 'contexts'],
+    install_requires=['pytest<6', 'contexts'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Framework :: Pytest',


### PR DESCRIPTION
Usages of ContextsCollector should be switched to use ContextsCollector.from_parent instead, but pinning the pytest version is quicker